### PR TITLE
Fix drop of pinned types

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,7 +81,6 @@ macro_rules! define_struct {
                         __private_inner: unsafe {
                             ::core::mem::transmute::<_, $crate::__private_mod::ErasedStorage<{ $struct_name::__SIZE }, { $struct_name::__ALIGN }>>(inner)
                         },
-                        __phantom: ::core::marker::PhantomData,
                     };
                     {
                         let $created_value = __stacklover_create( $($param),* );
@@ -178,7 +177,6 @@ macro_rules! define_struct {
                         __private_inner: unsafe {
                             ::core::mem::transmute::<_, $crate::__private_mod::ErasedStorage<{ $struct_name::__SIZE }, { $struct_name::__ALIGN }>>(inner)
                         },
-                        __phantom: ::core::marker::PhantomData,
                     };
                     {
                         let $created_value = __stacklover_create( $($param),* ).await;
@@ -212,17 +210,6 @@ macro_rules! __define_struct {
                 { $struct_name::__SIZE },
                 { $struct_name::__ALIGN },
             >,
-            #[doc(hidden)]
-            __phantom: ::core::marker::PhantomData<(
-                // for !Send + !Sync by default
-                *const (),
-                // for !Unpin by default
-                ::core::marker::PhantomPinned,
-                // for !UnwindSafe by default
-                ::core::marker::PhantomData<&'static mut ()>,
-                // for !Sync + !RefUnwindSafe by default
-                ::core::marker::PhantomData<::core::cell::UnsafeCell<()>>,
-            )>,
         }
     };
 }
@@ -432,7 +419,6 @@ macro_rules! __impl_traits {
                     __private_inner: unsafe {
                         ::core::mem::transmute::<_, $crate::__private_mod::ErasedStorage<{ $struct_name::__SIZE }, { $struct_name::__ALIGN }>>(cloned)
                     },
-                    __phantom: ::core::marker::PhantomData,
                 }
             }
         }
@@ -490,6 +476,16 @@ pub mod __private_mod {
     {
         _array: ::core::mem::MaybeUninit<[u8; SIZE]>,
         _zero: <ConstUsize<ALIGN> as ToAlignedZst>::AlignedZst,
-        _pinned: ::core::marker::PhantomPinned,
+        #[allow(clippy::type_complexity)]
+        _phantom: ::core::marker::PhantomData<(
+            // for !Send + !Sync by default
+            *const (),
+            // for !Unpin by default
+            ::core::marker::PhantomPinned,
+            // for !UnwindSafe by default
+            ::core::marker::PhantomData<&'static mut ()>,
+            // for !Sync + !RefUnwindSafe by default
+            ::core::marker::PhantomData<::core::cell::UnsafeCell<()>>,
+        )>,
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -276,7 +276,7 @@ macro_rules! __assert_and_as_ref_and_as_mut_and_into_inner_and_drop {
                 if true {
                     unsafe {
                         ::core::mem::transmute::<
-                            &mut$crate::__private_mod::ErasedStorage<
+                            &mut $crate::__private_mod::ErasedStorage<
                                 { $struct_name::__SIZE },
                                 { $struct_name::__ALIGN },
                             >,
@@ -285,7 +285,7 @@ macro_rules! __assert_and_as_ref_and_as_mut_and_into_inner_and_drop {
                     }
                 } else {
                     // _self for lifetime
-                    fn mut_unreachable<S, T>(_self: &S, _: T) -> &mut T {
+                    fn mut_unreachable<S, T>(_self: &mut S, _: T) -> &mut T {
                         ::core::unreachable!()
                     }
                     #[allow(unreachable_code)]
@@ -317,39 +317,14 @@ macro_rules! __assert_and_as_ref_and_as_mut_and_into_inner_and_drop {
             pub fn as_pin_mut(
                 self: ::core::pin::Pin<&mut Self>,
             ) -> ::core::pin::Pin<&mut ($inner_type)> {
-                if true {
-                    unsafe { ::core::mem::transmute(self) }
-                } else {
-                    // _self for lifetime
-                    fn pin_mut_unreachable<S, T>(
-                        _self: ::core::pin::Pin<&mut S>,
-                        _: T,
-                    ) -> ::core::pin::Pin<&mut T> {
-                        ::core::unreachable!()
-                    }
-                    #[allow(unreachable_code)]
-                    pin_mut_unreachable(self, __stacklover_inner_unreachable())
-                }
+                unsafe { self.map_unchecked_mut(Self::as_mut) }
             }
         }
 
         impl ::core::ops::Drop for $struct_name {
             #[inline(always)]
             fn drop(&mut self) {
-                let _ = if true {
-                    unsafe {
-                        ::core::mem::transmute::<
-                            $crate::__private_mod::ErasedStorage<
-                                { $struct_name::__SIZE },
-                                { $struct_name::__ALIGN },
-                            >,
-                            _,
-                        >(self.__private_inner)
-                    }
-                } else {
-                    #[allow(unreachable_code)]
-                    __stacklover_inner_unreachable()
-                };
+                unsafe { ::core::ptr::drop_in_place(self.as_mut()) }
             }
         }
     };
@@ -515,5 +490,6 @@ pub mod __private_mod {
     {
         _array: ::core::mem::MaybeUninit<[u8; SIZE]>,
         _zero: <ConstUsize<ALIGN> as ToAlignedZst>::AlignedZst,
+        _pinned: ::core::marker::PhantomPinned,
     }
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -476,8 +476,10 @@ fn it_works_with_as_pin_drop() {
     impl Drop for Trap {
         fn drop(&mut self) {
             let this = unsafe { Pin::new_unchecked(self) };
-            // simulate a read if the ptr was initialized
             if !this.ptr.is_null() {
+                // If ptr is initialized, we know that self has been pinned and hasn't moved. Assert that this is still the case.
+                assert_eq!(this.ptr, &this.data, "ptr should point to our own data");
+                // Simulate a read if the ptr was initialized to trap miri if the pointer provenance was somehow disabled.
                 let _ = unsafe { &*this.ptr }.to_string();
             }
         }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -445,6 +445,7 @@ async fn it_works_with_async_and_deriving_traits_and_wrap_params() {
 async fn it_works_with_as_pin_mut() {
     stacklover::define_struct! {
         Future1,
+        #[allow(clippy::manual_async_fn)]
         fn () -> impl Future<Output=i32> {
             async {
                 tokio::time::sleep(tokio::time::Duration::from_nanos(1)).await;
@@ -463,6 +464,52 @@ async fn it_works_with_as_pin_mut() {
     }
 
     assert_eq!(Future1::new().await, 10);
+}
+
+#[test]
+fn it_works_with_as_pin_drop() {
+    struct Trap {
+        data: String,
+        ptr: *const String,
+        _marker: std::marker::PhantomPinned,
+    }
+    impl Drop for Trap {
+        fn drop(&mut self) {
+            let this = unsafe { Pin::new_unchecked(self) };
+            // simulate a read if the ptr was initialized
+            if !this.ptr.is_null() {
+                let _ = unsafe { &*this.ptr }.to_string();
+            }
+        }
+    }
+    trait Init {
+        fn init(self: Pin<&mut Self>);
+    }
+    impl Init for Trap {
+        fn init(self: Pin<&mut Self>) {
+            let self_ptr = &self.data as *const String;
+            let this = unsafe { self.get_unchecked_mut() };
+            this.ptr = self_ptr;
+        }
+    }
+    fn create() -> Trap {
+        Trap {
+            data: "foobar".to_string(),
+            ptr: core::ptr::null(),
+            _marker: std::marker::PhantomPinned,
+        }
+    }
+    stacklover::define_struct! {
+        PinUpType,
+        fn () -> impl Init {
+            create()
+        },
+        impls = (), // NOTE: !Unpin
+    }
+    let mut pinned = PinUpType::new();
+    let pinned = ::core::pin::pin!(pinned);
+    pinned.as_pin_mut().init();
+    // ... pinned is dropped here, which activates the trap in miri.
 }
 
 #[tokio::test]

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -508,8 +508,9 @@ fn it_works_with_as_pin_drop() {
         },
         impls = (), // NOTE: !Unpin
     }
-    let mut pinned = PinUpType::new();
-    let pinned = ::core::pin::pin!(pinned);
+    let pinned = PinUpType::new();
+    // TODO: replace with ::core::pin::pin! when the MSRV is bumped to >1.68.0
+    futures::pin_mut!(pinned);
     pinned.as_pin_mut().init();
     // ... pinned is dropped here, which activates the trap in miri.
 }


### PR DESCRIPTION
A pinned value can not be moved before its drop impl is called. This is strict, so we can not copy the storage in the Drop impl. Further, the storage is now marked `PhantomPinned`, so that the compiler doesn't move it for us by accident.

A few small stylistic changes to aid readability are included too, because my linter complained too much.

In `as_pin_mut`, I'm trying hard to avoid a `transmute`, the existing API can be used, and is much more forgiving if for some reason pointer metadata or [provenance](https://rust-lang.github.io/unsafe-code-guidelines/glossary.html#pointer-provenance) is laid out differently.

I've added a test case that you can verify to complain under the previous code with miri enabled to show off the bug. A pointer to pinned data is accessed in the Drop impl, so the value must not have been moved!